### PR TITLE
new mandatory yaml fields: description and messageSchemaLocation

### DIFF
--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/TopicDetails.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/TopicDetails.java
@@ -10,6 +10,10 @@ import java.util.Optional;
 @JsonDeserialize(builder = TopicDetails.Builder.class)
 public interface TopicDetails {
 
+    String getDescription();
+
+    String getMessageSchemaLocation();
+
     Integer getPartitions();
 
     Optional<Integer> getReplication();


### PR DESCRIPTION
Below 2 fields are now required when defined a new topic:

* `description`
	* data type: String	
	* A short description of the kind of the message types that are hosted in the topic

* `messageSchemaLocation`
	* data type: String
	* A url that points to the location of the message schema definition

Validation
Missing or empty properties result in `[INVALID]` validation error when running the `validate`, `plan` or `apply` commands. 
